### PR TITLE
TECH-1607 : make the module compatible with Jahia 8.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.2.0.0-SNAPSHOT</version>
+        <version>8.1.2.0</version>
     </parent>
 
     <artifactId>jcr-auth-provider</artifactId>
@@ -66,6 +66,7 @@
     </scm>
 
     <properties>
+        <jahia.plugin.version>6.9</jahia.plugin.version>
         <jahia-depends>default,jahia-authentication</jahia-depends>
         <require-capability>osgi.extender;filter:="(osgi.extender=org.jahia.bundles.blueprint.extender.config)"</require-capability>
         <jahia-module-signature>MCwCFDD3cVWXDDItk1rWeWvJquD/CyHfAhRGZE+GeHJCSWTMzI5fJ0KSGWSeHQ==</jahia-module-signature>

--- a/src/main/import/repository.xml
+++ b/src/main/import/repository.xml
@@ -7,7 +7,6 @@
                              j:title="JCR Auth provider"
                              jcr:primaryType="jnt:module">
 
-                <portlets jcr:primaryType="jnt:portletFolder"/>
                 <files jcr:primaryType="jnt:folder"/>
                 <contents jcr:primaryType="jnt:contentFolder"/>
                 <templates j:rootTemplatePath="/base" jcr:primaryType="jnt:templatesFolder">

--- a/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
+++ b/src/main/resources/joant_jcrOAuthView/html/jcrOAuthView.jsp
@@ -3,7 +3,6 @@
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
-<%@ taglib prefix="ui" uri="http://www.jahia.org/tags/uiComponentsLib" %>
 <%@ taglib prefix="functions" uri="http://www.jahia.org/tags/functions" %>
 <%@ taglib prefix="query" uri="http://www.jahia.org/tags/queryLib" %>
 <%@ taglib prefix="utility" uri="http://www.jahia.org/tags/utilityLib" %>


### PR DESCRIPTION
https://jira.jahia.org/browse/TECH-1607 

The dependency to jahia 8.2.x was required to match the portlet packages removal from the core. 
As portlets (and what was bringing the portlet depdendency) were not used in this project, we can remove the 8.2.x. jahia parent requirement.